### PR TITLE
fix: resolve SyntaxError caused by missing comma in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const ignorePatterns = [
 
 const essentialPaths = [
   "templates/**",
-  "ui-plugin/dist/**"
+  "ui-plugin/dist/**",
   "README.md",
   "LICENSE",
   "i18n/**",


### PR DESCRIPTION
### 问题描述 (Problem)

在基于 Halo 2.x 的主题（如 `theme-fuwari`）中执行 `pnpm run build` 时，构建流程在执行 `theme-package` 阶段会报错并异常退出，错误日志如下：

```text
file:///.../node_modules/@halo-dev/theme-package-cli/index.js:26
  "README.md",
  ^^^^^^^^^^^

SyntaxError: Unexpected string